### PR TITLE
Fix generate jc clients, add in SafeContractResolver.cs

### DIFF
--- a/Helpers/SafeContractResolver.cs
+++ b/Helpers/SafeContractResolver.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System.Reflection;
+
+namespace JCCommon.Helpers
+{
+    /// <summary>
+    /// This is used so the Requried field doesn't always apply and look for a null value on properties of the generated classes.
+    /// </summary>
+    public class SafeContractResolver : DefaultContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var jsonProp = base.CreateProperty(member, memberSerialization);
+            jsonProp.Required = Required.Default;
+            return jsonProp;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Generating Clients:
 	2. Download the latest NSwagStudio: https://github.com/RicoSuter/NSwag/wiki/NSwagStudio
 
 	Scripted version:
-	1. Run generate-jc-clients after adjusting the paths. It may take a while to run this script, let it run.
+	1. Copy over the new RAML's from the JC-Interface project (private repo) into API References
+	2. Run generate-jc-clients. It may take a while to run this script, let it run.
 
 	Manual: 
 	1.*** MAKE SURE YOU REMOVE THE baseUri from the RAML file ***

--- a/generate_jc_clients
+++ b/generate_jc_clients
@@ -1,10 +1,7 @@
 echo "Ensure oas-raml-converter and nswag are installed globally."
-jc_interface_raml_folder="/C/Code/Work/JC-Interface/src/main/api/"
-output_raml_folder="/C/Code/Work/supreme-court-viewer/jc-interface-client/API References/"
+input_raml_folder="./API References/"
 
-echo "Copying from $jc_interface_raml_folder to $output_raml_folder"
-cp $jc_interface_raml_folder*.raml "$output_raml_folder"
-cd "${output_raml_folder}"
+cd "${input_raml_folder}"
 echo "Replacing baseUri"
 sed -i 's,baseUri:.*$,,g' *.raml
 


### PR DESCRIPTION
- Fix generate jc clients
- Add in SafeContractResolver.cs, sets all required fields to non required. Allows for fields to be set to null.